### PR TITLE
feat(api): add request retries & fix(container): Error on failing to get published apps

### DIFF
--- a/Scripts/Modules/API-Helper.psm1
+++ b/Scripts/Modules/API-Helper.psm1
@@ -137,6 +137,7 @@ function Resolve-AlpacaApiError {
     )
 
     $errorMessage = Get-AlpacaApiErrorMessage -ErrorRecord $ErrorRecord
+    Write-AlpacaError -Message $errorMessage
 
     $updatedErrorRecord  = [System.Management.Automation.ErrorRecord]::new($ErrorRecord, $ErrorRecord.Exception)
     $updatedErrorRecord.ErrorDetails = [System.Management.Automation.ErrorDetails]::new($errorMessage)

--- a/Scripts/Modules/API-Helper.psm1
+++ b/Scripts/Modules/API-Helper.psm1
@@ -59,10 +59,21 @@ function Invoke-AlpacaApiRequest {
         [string] $Url,
         [string] $Method = 'Get',
         [Hashtable] $Headers,
-        [object] $Body
+        [object] $Body,
+        [int] $Retries = 0,
+        [System.Net.HttpStatusCode[]] $NoRetryStatusCodes = @()
     )
     
-    $maxAttempts = 5
+    $NoRetryStatusCodes += 
+        [System.Net.HttpStatusCode]::BadRequest,           # 400
+        [System.Net.HttpStatusCode]::Unauthorized,         # 401
+        [System.Net.HttpStatusCode]::Forbidden,            # 403
+        [System.Net.HttpStatusCode]::MethodNotAllowed,     # 405
+        [System.Net.HttpStatusCode]::Conflict,             # 409
+        [System.Net.HttpStatusCode]::UnprocessableEntity,  # 422
+        [System.Net.HttpStatusCode]::NotImplemented        # 501
+
+    $maxAttempts = $Retries + 1
     foreach ($attempt in 1..$maxAttempts) {
         Write-AlpacaDebug -Message "Invoking Alpaca-Api: $Url ($Method) - Attempt $attempt of $maxAttempts"
         try {
@@ -70,15 +81,19 @@ function Invoke-AlpacaApiRequest {
         }
         catch {
             if ($attempt -lt $maxAttempts) {
-                Write-AlpacaDebug -Message (Get-AlpacaApiErrorMessage -ErrorRecord $_)
+                if ($_.Exception -is [System.Net.Http.HttpRequestException] -and $_.Exception.StatusCode -in $NoRetryStatusCodes) {
+                    Write-AlpacaDebug -Message "Not retying for Http status code $([int]$_.Exception.StatusCode)"
+                }
+                else {
+                    Write-AlpacaDebug -Message (Get-AlpacaApiErrorMessage -ErrorRecord $_)
+                    $waitSeconds = [Math]::Pow(2, $attempt - 1)
+                    Write-AlpacaDebug -Message "Retrying in $waitSeconds second(s)..."
+                    Start-Sleep -Seconds $waitSeconds
+                    continue
+                }
+            }
 
-                $waitSeconds = [Math]::Pow(2, $attempt - 1)
-                Write-AlpacaDebug -Message "Retrying in $waitSeconds second(s)..."
-                Start-Sleep -Seconds $waitSeconds
-            }
-            else {
-                Resolve-AlpacaApiError -ErrorRecord $_
-            }
+            Resolve-AlpacaApiError -ErrorRecord $_
         }
     }
 }

--- a/Scripts/Modules/API-Helper.psm1
+++ b/Scripts/Modules/API-Helper.psm1
@@ -152,7 +152,6 @@ function Resolve-AlpacaApiError {
     )
 
     $errorMessage = Get-AlpacaApiErrorMessage -ErrorRecord $ErrorRecord
-    Write-AlpacaError -Message $errorMessage
 
     $updatedErrorRecord  = [System.Management.Automation.ErrorRecord]::new($ErrorRecord, $ErrorRecord.Exception)
     $updatedErrorRecord.ErrorDetails = [System.Management.Automation.ErrorDetails]::new($errorMessage)

--- a/Scripts/Modules/API-Helper.psm1
+++ b/Scripts/Modules/API-Helper.psm1
@@ -62,18 +62,29 @@ function Invoke-AlpacaApiRequest {
         [object] $Body
     )
     
-    Write-AlpacaDebug -Message "Invoking Alpaca-Api: $Url ($Method)"
-    
-    try {
-        Invoke-RestMethod -Uri $Url -Method $Method -Headers $Headers -Body $Body -AllowInsecureRedirect
-    }
-    catch {
-        Resolve-AlpacaApiError -ErrorRecord $_
+    $maxAttempts = 5
+    foreach ($attempt in 1..$maxAttempts) {
+        Write-AlpacaDebug -Message "Invoking Alpaca-Api: $Url ($Method) - Attempt $attempt of $maxAttempts"
+        try {
+            return Invoke-RestMethod -Uri $Url -Method $Method -Headers $Headers -Body $Body -AllowInsecureRedirect
+        }
+        catch {
+            if ($attempt -lt $maxAttempts) {
+                Write-AlpacaDebug -Message (Get-AlpacaApiErrorMessage -ErrorRecord $_)
+
+                $waitSeconds = [Math]::Pow(2, $attempt - 1)
+                Write-AlpacaDebug -Message "Retrying in $waitSeconds second(s)..."
+                Start-Sleep -Seconds $waitSeconds
+            }
+            else {
+                Resolve-AlpacaApiError -ErrorRecord $_
+            }
+        }
     }
 }
 Export-ModuleMember -Function Invoke-AlpacaApiRequest
 
-function Resolve-AlpacaApiError {
+function Get-AlpacaApiErrorMessage {
     Param(
         [Parameter(Mandatory = $true)]
         [System.Management.Automation.ErrorRecord] $ErrorRecord
@@ -105,7 +116,7 @@ function Resolve-AlpacaApiError {
     }
 
     $errorMessage = "Alpaca-API request failed"
-    
+
     $errorContext = @($problemDetails.status, $problemDetails.title, $problemDetails.instance) | Where-Object { $_ }
     if ($errorContext) {
         $errorMessage += " ($($errorContext -join " "))"
@@ -114,6 +125,18 @@ function Resolve-AlpacaApiError {
     if ($problemDetails.detail) {
         $errorMessage += "`n$($problemDetails.detail)"
     }
+
+    return $errorMessage
+}
+Export-ModuleMember -Function Get-AlpacaApiErrorMessage
+
+function Resolve-AlpacaApiError {
+    Param(
+        [Parameter(Mandatory = $true)]
+        [System.Management.Automation.ErrorRecord] $ErrorRecord
+    )
+
+    $errorMessage = Get-AlpacaApiErrorMessage -ErrorRecord $ErrorRecord
 
     $updatedErrorRecord  = [System.Management.Automation.ErrorRecord]::new($ErrorRecord, $ErrorRecord.Exception)
     $updatedErrorRecord.ErrorDetails = [System.Management.Automation.ErrorDetails]::new($errorMessage)

--- a/Scripts/Modules/API-Helper.psm1
+++ b/Scripts/Modules/API-Helper.psm1
@@ -82,7 +82,7 @@ function Invoke-AlpacaApiRequest {
         catch {
             if ($attempt -lt $maxAttempts) {
                 if ($_.Exception -is [System.Net.Http.HttpRequestException] -and $_.Exception.StatusCode -in $NoRetryStatusCodes) {
-                    Write-AlpacaDebug -Message "Not retying for Http status code $([int]$_.Exception.StatusCode)"
+                    Write-AlpacaDebug -Message "Not retrying for Http status code $([int]$_.Exception.StatusCode)"
                 }
                 else {
                     Write-AlpacaDebug -Message (Get-AlpacaApiErrorMessage -ErrorRecord $_)

--- a/Scripts/Modules/Get-AlpacaAppInfo.psm1
+++ b/Scripts/Modules/Get-AlpacaAppInfo.psm1
@@ -11,7 +11,7 @@ function Get-AlpacaAppInfo {
 
         $apiUrl = Get-AlpacaEndpointUrlWithParam -Controller "Container" -Endpoint "Exec" -Ressource $ContainerName -RouteSuffix "appInfo"
         Write-AlpacaOutput "Connecting to $apiUrl"
-        $result = Invoke-AlpacaApiRequest -Url $apiUrl -Method 'Get' -Headers $headers
+        $result = Invoke-AlpacaApiRequest -Url $apiUrl -Method 'Get' -Headers $headers -Retries 3
         return $result
     }
 }

--- a/Scripts/Modules/Get-AlpacaConfigSyncStatus.psm1
+++ b/Scripts/Modules/Get-AlpacaConfigSyncStatus.psm1
@@ -9,7 +9,7 @@ function Get-AlpacaConfigSyncStatus {
     $headers = Get-AlpacaAuthenticationHeaders -Token $Token
     $apiUrl = Get-AlpacaEndpointUrlWithParam -Controller "GitHub" -Endpoint "ConfigSync"
     try {
-        return Invoke-AlpacaApiRequest -Url $apiUrl -Method Get -Headers $headers
+        return Invoke-AlpacaApiRequest -Url $apiUrl -Method Get -Headers $headers -Retries 3
     }
     catch {
         Write-AlpacaError "Failed to get config sync status from Alpaca backend: $_"

--- a/Scripts/Modules/Get-AlpacaDependencyApps.psm1
+++ b/Scripts/Modules/Get-AlpacaDependencyApps.psm1
@@ -29,7 +29,7 @@ function Get-AlpacaDependencyApps {
     $resource = "$($owner)/$($repository)/$($project -replace '^\.$', '_')"
     $apiUrl = Get-AlpacaEndpointUrlWithParam -Controller "GitHub" -Endpoint "Project" -Ressource $resource -QueryParams $queryParams
 
-    $containerConfig = Invoke-AlpacaApiRequest -Url $apiUrl -Method 'GET' -Headers $headers
+    $containerConfig = Invoke-AlpacaApiRequest -Url $apiUrl -Method 'GET' -Headers $headers -Retries 3
     $artifacts = $containerConfig.containerConfigurations[0].artifacts
     $artifacts = $artifacts | Where-Object { $_.target -eq 'App' }
     $artifacts = $artifacts | Where-Object { $_.IgnoreIn -ne 'Build' }

--- a/Scripts/Modules/New-AlpacaContainer.psm1
+++ b/Scripts/Modules/New-AlpacaContainer.psm1
@@ -42,7 +42,7 @@ function New-AlpacaContainer {
         }
     } 
     $body = $request | ConvertTo-Json -Depth 10
-    $response = Invoke-AlpacaApiRequest -Url $apiUrl -Method 'POST' -Headers $headers -Body $body
+    $response = Invoke-AlpacaApiRequest -Url $apiUrl -Method 'POST' -Headers $headers -Body $body -Retries 3
 
     $container = [pscustomobject]@{
         Project   = $Project

--- a/Scripts/Modules/Remove-AlpacaContainer.psm1
+++ b/Scripts/Modules/Remove-AlpacaContainer.psm1
@@ -18,7 +18,7 @@ function Remove-AlpacaContainer {
 
         $apiUrl = Get-AlpacaEndpointUrlWithParam -Controller "Container" -Endpoint "Container" -Ressource $Container.Id
         
-        Invoke-AlpacaApiRequest -Url $apiUrl -Method 'DELETE' -Headers $headers | Out-Null
+        Invoke-AlpacaApiRequest -Url $apiUrl -Method 'DELETE' -Headers $headers -Retries 3 -NoRetryStatusCodes @([System.Net.HttpStatusCode]::NotFound) | Out-Null
 
         Write-AlpacaOutput "Container '$($Container.Id)' deleted"
     } catch {

--- a/Scripts/Modules/Sync-AlpacaConfigs.psm1
+++ b/Scripts/Modules/Sync-AlpacaConfigs.psm1
@@ -15,7 +15,7 @@ function Sync-AlpacaConfigs {
     $apiUrl = Get-AlpacaEndpointUrlWithParam -Controller "GitHub" -Endpoint "ConfigSync"
 
     $body = @{ secrets = $Secrets; variables = $Variables } | ConvertTo-Json -Depth 10
-    Invoke-AlpacaApiRequest -Url $apiUrl -Method Post -Headers $headers -Body $body | Out-Null
+    Invoke-AlpacaApiRequest -Url $apiUrl -Method Post -Headers $headers -Body $body -Retries 3 | Out-Null
 
     Write-AlpacaOutput "Synced configs to Alpaca backend"
 }

--- a/Scripts/Modules/Wait-AlpacaContainerImageReady.psm1
+++ b/Scripts/Modules/Wait-AlpacaContainerImageReady.psm1
@@ -33,7 +33,7 @@ function Wait-AlpacaContainerImageReady {
         $attemps = 1
         do {
             try {
-                $containerResult = Invoke-AlpacaApiRequest -Url $apiUrl -Method 'GET' -Headers $headers
+                $containerResult = Invoke-AlpacaApiRequest -Url $apiUrl -Method 'GET' -Headers $headers -Retries 3
             }
             catch {
                 Write-AlpacaError "Error while getting container status: $_"

--- a/Scripts/Overrides/RunAlPipeline/PublishBcContainerApp.ps1
+++ b/Scripts/Overrides/RunAlPipeline/PublishBcContainerApp.ps1
@@ -33,7 +33,7 @@ else {
 
 
 $publishedAppInfos = Get-Variable -Name alpacaPublishedAppInfos -ValueOnly -Scope Script -ErrorAction Ignore
-if (! $publishedAppInfos) {
+if ($null -eq $publishedAppInfos) {
     $publishedAppInfos = Get-AlpacaAppInfo -Token $env:_token -ContainerName $env:ALPACA_CONTAINER_ID
     Set-Variable -Name alpacaPublishedAppInfos -Value $publishedAppInfos -Scope Script
 }

--- a/Scripts/Overrides/RunAlPipeline/PublishBcContainerApp.ps1
+++ b/Scripts/Overrides/RunAlPipeline/PublishBcContainerApp.ps1
@@ -35,6 +35,7 @@ else {
 $publishedAppInfos = Get-Variable -Name alpacaPublishedAppInfos -ValueOnly -Scope Script -ErrorAction Ignore
 if (! $publishedAppInfos) {
     $publishedAppInfos = Get-AlpacaAppInfo -Token $env:_token -ContainerName $env:ALPACA_CONTAINER_ID
+    Set-Variable -Name alpacaPublishedAppInfos -Value $publishedAppInfos -Scope Script
 }
 
 $compilerFolder = (GetCompilerFolder)

--- a/Scripts/Overrides/RunAlPipeline/PublishBcContainerApp.ps1
+++ b/Scripts/Overrides/RunAlPipeline/PublishBcContainerApp.ps1
@@ -34,13 +34,7 @@ else {
 
 $publishedAppInfos = Get-Variable -Name alpacaPublishedAppInfos -ValueOnly -Scope Script -ErrorAction Ignore
 if (! $publishedAppInfos) {
-    try {
-        $publishedAppInfos = Get-AlpacaAppInfo -Token $env:_token -ContainerName $env:ALPACA_CONTAINER_ID
-    }
-    catch {
-        Write-AlpacaOutput "Error occurred while getting published app infos: $_"
-        $publishedAppInfos = @()
-    }
+    $publishedAppInfos = Get-AlpacaAppInfo -Token $env:_token -ContainerName $env:ALPACA_CONTAINER_ID
 }
 
 $compilerFolder = (GetCompilerFolder)


### PR DESCRIPTION
**API Retries:** ([AB#4708](https://dev.azure.com/cc-ppi/83f75d99-795d-45dc-8543-9fe1918ff7f9/_workitems/edit/4708))

* Added `$Retries` and `$NoRetryStatusCodes` parameters to `Invoke-AlpacaApiRequest`, implementing exponential backoff and skipping retries for specific HTTP status codes.
* Updated all module functions that call `Invoke-AlpacaApiRequest` (such as `Get-AlpacaAppInfo`, `Get-AlpacaConfigSyncStatus`, `Get-AlpacaDependencyApps`, `New-AlpacaContainer`, `Remove-AlpacaContainer`, `Sync-AlpacaConfigs`, `Wait-AlpacaContainerImageReady`) to use the new retry functionality, typically with 3 retries. [[1]](diffhunk://#diff-47612468828038e919c91067c0f6a941f56de6802d0945fce23ae0b256d0c463L14-R14) [[2]](diffhunk://#diff-c66b366d7a80f0d6e7e1d3684067900a005e79366e8c3819f75f85c2eac0c0d9L12-R12) [[3]](diffhunk://#diff-676c982eb1f3b2eec8c6d5713156adab85d75a5506cf5b2cd7bdb848c73cfb09L32-R32) [[4]](diffhunk://#diff-73198a54cf38fb6e89441675dea6390f6639451dbd304cb25bef345a727e0edaL45-R45) [[5]](diffhunk://#diff-5a3470d7c24b460e3d5ff91dec89cc62eebbae894452117fcf6af6ccae56d68bL21-R21) [[6]](diffhunk://#diff-652cfd2ef00a4980d390638aa36af9a79160bd63d29e954233c03f27b1d44fa1L18-R18) [[7]](diffhunk://#diff-5a3325e25f9937282b863bd9efb664c4fc06e3338f050b4b726e7f3ff6adfe88L36-R36)

**Retrieving published App:** ([AB#4656](https://dev.azure.com/cc-ppi/83f75d99-795d-45dc-8543-9fe1918ff7f9/_workitems/edit/4656))

* Removed try/catch for retrieving published apps to throw possible errors and stop the workflow
* Improved variable initialization for published apps