### PR TITLE
Do not create unnecessary alpaca containers

### DIFF
--- a/Actions/CreateContainers/CreateContainers.ps1
+++ b/Actions/CreateContainers/CreateContainers.ps1
@@ -10,11 +10,6 @@ $ALGoHelperPath = Join-Path -Path $PSScriptRoot -ChildPath "../../../../../micro
 Write-AlpacaDebug "ALGoHelperPath: $ALGoHelperPath"
 . ($ALGoHelperPath)
 
-Write-Host "GH Workspace: $($ENV:GITHUB_WORKSPACE)"
-$set = join-path "$ENV:GITHUB_WORKSPACE" $(Join-Path '.AL-Go' 'settings.json')
-Write-Host "Set: $set; $(Test-Path $set)"
-
-
 try {
     # BuildOrderJson is sonething like this: [{"projects":["ProjectA","ProjectB"],"buildDimensions":[{"project":"ProjectA","gitHubRunner":"\"ubuntu-latest\"","githubRunnerShell":"pwsh","buildMode":"Default","projectName":"ProjectA"},{"project":"ProjectA","gitHubRunner":"\"ubuntu-latest\"","githubRunnerShell":"pwsh","buildMode":"Clean","projectName":"ProjectA"},{"project":"ProjectB","gitHubRunner":"\"ubuntu-latest\"","githubRunnerShell":"pwsh","buildMode":"Default","projectName":"ProjectB"}],"projectsCount":2}]
     # or with multi level projects like this [{"buildDimensions":[{"project":"ProjectA","gitHubRunner":"\"ubuntu-latest\"","buildMode":"Default","projectName":"ProjectA","githubRunnerShell":"pwsh"},{"project":"ProjectA","gitHubRunner":"\"ubuntu-latest\"","buildMode":"Clean","projectName":"ProjectA","githubRunnerShell":"pwsh"}],"projects":["ProjectA"],"projectsCount":1},{"buildDimensions":[{"project":"ProjectB","gitHubRunner":"\"ubuntu-latest\"","buildMode":"Default","projectName":"ProjectB","githubRunnerShell":"pwsh"}],"projects":["ProjectB"],"projectsCount":1}]
@@ -32,10 +27,13 @@ $containers = @()
 
 try {
     foreach ($buildDimension in $BuildOrder.buildDimensions) {
-        Write-AlpacaOutput "Determine whether a container is necessary for project '$($buildDimension.project)' with build mode '$($buildDimension.buildMode)'"
+        Write-AlpacaDebug "Determine whether a container is necessary for project '$($buildDimension.project)' with build mode '$($buildDimension.buildMode)'"
         $settings = ReadSettings -project $buildDimension.project -buildMode $buildDimension.buildMode
-        Write-AlpacaOutput "Settings: $($settings | convertto-json -compress)"
-        # TODO: decision making
+        Write-AlpacaDebug "Settings: $($settings | convertto-json -compress)"
+        if($settings.useCompilerFolder -and $settings.doNotPublishApps) {
+            Write-AlpacaOutput "No container required for project '$($buildDimension.project)' with build mode '$($buildDimension.buildMode)'"
+            continue
+        }
         Write-AlpacaOutput "Creating container for project '$($buildDimension.project)' with build mode '$($buildDimension.buildMode)'"
         $containers += New-AlpacaContainer -Project $buildDimension.project -Token $Token -BuildMode $buildDimension.buildMode
     }

--- a/Actions/CreateContainers/CreateContainers.ps1
+++ b/Actions/CreateContainers/CreateContainers.ps1
@@ -10,6 +10,11 @@ $ALGoHelperPath = Join-Path -Path $PSScriptRoot -ChildPath "../../../../../micro
 Write-AlpacaDebug "ALGoHelperPath: $ALGoHelperPath"
 . ($ALGoHelperPath)
 
+Write-Host "GH Workspace: $($ENV:GITHUB_WORKSPACE)"
+$set = join-path "$ENV:GITHUB_WORKSPACE" $(Join-Path '.AL-Go' 'settings.json')
+Write-Host "Set: $set; $(Test-Path $set)"
+
+
 try {
     # BuildOrderJson is sonething like this: [{"projects":["ProjectA","ProjectB"],"buildDimensions":[{"project":"ProjectA","gitHubRunner":"\"ubuntu-latest\"","githubRunnerShell":"pwsh","buildMode":"Default","projectName":"ProjectA"},{"project":"ProjectA","gitHubRunner":"\"ubuntu-latest\"","githubRunnerShell":"pwsh","buildMode":"Clean","projectName":"ProjectA"},{"project":"ProjectB","gitHubRunner":"\"ubuntu-latest\"","githubRunnerShell":"pwsh","buildMode":"Default","projectName":"ProjectB"}],"projectsCount":2}]
     # or with multi level projects like this [{"buildDimensions":[{"project":"ProjectA","gitHubRunner":"\"ubuntu-latest\"","buildMode":"Default","projectName":"ProjectA","githubRunnerShell":"pwsh"},{"project":"ProjectA","gitHubRunner":"\"ubuntu-latest\"","buildMode":"Clean","projectName":"ProjectA","githubRunnerShell":"pwsh"}],"projects":["ProjectA"],"projectsCount":1},{"buildDimensions":[{"project":"ProjectB","gitHubRunner":"\"ubuntu-latest\"","buildMode":"Default","projectName":"ProjectB","githubRunnerShell":"pwsh"}],"projects":["ProjectB"],"projectsCount":1}]

--- a/Actions/CreateContainers/CreateContainers.ps1
+++ b/Actions/CreateContainers/CreateContainers.ps1
@@ -43,11 +43,9 @@ catch {
     throw "Failed to create containers"
 }
 finally {
-    Write-AlpacaOutput "Created $($containers.Count) of $($BuildOrder.buildDimensions.Count) containers"
+    Write-AlpacaOutput "Created $($containers.Count) containers for $($BuildOrder.buildDimensions.Count) build dimensions."
 
     $containersJson = $containers | ConvertTo-Json -Depth 99 -Compress -AsArray
     Add-Content -Encoding UTF8 -Path $env:GITHUB_ENV -Value "ALPACA_CONTAINERS_JSON=$($containersJson)"
     Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "containersJson=$($containersJson)"
 }
-
-throw

--- a/Actions/CreateContainers/CreateContainers.ps1
+++ b/Actions/CreateContainers/CreateContainers.ps1
@@ -7,6 +7,8 @@ param(
 
 Import-Module (Join-Path -Path $PSScriptRoot -ChildPath "..\..\Scripts\Modules\Alpaca.psd1" -Resolve) -DisableNameChecking
 
+. (Join-Path -Path $PSScriptRoot -ChildPath "..\AL-Go-Helper.ps1" -Resolve)
+
 try {
     # BuildOrderJson is sonething like this: [{"projects":["ProjectA","ProjectB"],"buildDimensions":[{"project":"ProjectA","gitHubRunner":"\"ubuntu-latest\"","githubRunnerShell":"pwsh","buildMode":"Default","projectName":"ProjectA"},{"project":"ProjectA","gitHubRunner":"\"ubuntu-latest\"","githubRunnerShell":"pwsh","buildMode":"Clean","projectName":"ProjectA"},{"project":"ProjectB","gitHubRunner":"\"ubuntu-latest\"","githubRunnerShell":"pwsh","buildMode":"Default","projectName":"ProjectB"}],"projectsCount":2}]
     # or with multi level projects like this [{"buildDimensions":[{"project":"ProjectA","gitHubRunner":"\"ubuntu-latest\"","buildMode":"Default","projectName":"ProjectA","githubRunnerShell":"pwsh"},{"project":"ProjectA","gitHubRunner":"\"ubuntu-latest\"","buildMode":"Clean","projectName":"ProjectA","githubRunnerShell":"pwsh"}],"projects":["ProjectA"],"projectsCount":1},{"buildDimensions":[{"project":"ProjectB","gitHubRunner":"\"ubuntu-latest\"","buildMode":"Default","projectName":"ProjectB","githubRunnerShell":"pwsh"}],"projects":["ProjectB"],"projectsCount":1}]
@@ -24,6 +26,10 @@ $containers = @()
 
 try {
     foreach ($buildDimension in $BuildOrder.buildDimensions) {
+        Write-AlpacaOutput "Determine whether a container is necessary for project '$($buildDimension.project)' with build mode '$($buildDimension.buildMode)'"
+        $settings = ReadSettings -project $buildDimension.project -buildMode $buildDimension.buildMode
+        Write-AlpacaOutput "Settings: $($settings | convertto-json -compress)"
+        # TODO: decision making
         Write-AlpacaOutput "Creating container for project '$($buildDimension.project)' with build mode '$($buildDimension.buildMode)'"
         $containers += New-AlpacaContainer -Project $buildDimension.project -Token $Token -BuildMode $buildDimension.buildMode
     }

--- a/Actions/CreateContainers/CreateContainers.ps1
+++ b/Actions/CreateContainers/CreateContainers.ps1
@@ -9,7 +9,9 @@ Import-Module (Join-Path -Path $PSScriptRoot -ChildPath "..\..\Scripts\Modules\A
 $ActionsDir = Resolve-Path (Join-Path -Path $PSScriptRoot -ChildPath "../../../../../")
 Write-AlpacaOutput "ActionsDir: $ActionsDir"
 gci $ActionsDir -recurse -Directory | %{Write-AlpacaOutput $_.FullName}
-. (Join-Path -Path $PSScriptRoot -ChildPath "../../../../../microsoft/AL-Go-Actions/AL-Go-Helper.ps1" -Resolve)
+$ALGoHelperPath = Join-Path -Path $PSScriptRoot -ChildPath "../../../../../microsoft/AL-Go-Actions/*/AL-Go-Helper.ps1" -Resolve
+Write-Host "ALGoHelperPath: $ALGoHelperPath"
+. ($ALGoHelperPath)
 
 try {
     # BuildOrderJson is sonething like this: [{"projects":["ProjectA","ProjectB"],"buildDimensions":[{"project":"ProjectA","gitHubRunner":"\"ubuntu-latest\"","githubRunnerShell":"pwsh","buildMode":"Default","projectName":"ProjectA"},{"project":"ProjectA","gitHubRunner":"\"ubuntu-latest\"","githubRunnerShell":"pwsh","buildMode":"Clean","projectName":"ProjectA"},{"project":"ProjectB","gitHubRunner":"\"ubuntu-latest\"","githubRunnerShell":"pwsh","buildMode":"Default","projectName":"ProjectB"}],"projectsCount":2}]

--- a/Actions/CreateContainers/CreateContainers.ps1
+++ b/Actions/CreateContainers/CreateContainers.ps1
@@ -6,8 +6,10 @@ param(
 )
 
 Import-Module (Join-Path -Path $PSScriptRoot -ChildPath "..\..\Scripts\Modules\Alpaca.psd1" -Resolve) -DisableNameChecking
-
-. (Join-Path -Path $PSScriptRoot -ChildPath "..\AL-Go-Helper.ps1" -Resolve)
+$ActionsDir = Resolve-Path (Join-Path -Path $PSScriptRoot -ChildPath "../../../../../)
+Write-AlpacaOutput "ActionsDir: $ActionsDir"
+gci $ActionsDir -recurse -Directory | %{Write-AlpacaOutput $_.FullName}
+. (Join-Path -Path $PSScriptRoot -ChildPath "../../../../../microsoft/AL-Go-Actions/AL-Go-Helper.ps1" -Resolve)
 
 try {
     # BuildOrderJson is sonething like this: [{"projects":["ProjectA","ProjectB"],"buildDimensions":[{"project":"ProjectA","gitHubRunner":"\"ubuntu-latest\"","githubRunnerShell":"pwsh","buildMode":"Default","projectName":"ProjectA"},{"project":"ProjectA","gitHubRunner":"\"ubuntu-latest\"","githubRunnerShell":"pwsh","buildMode":"Clean","projectName":"ProjectA"},{"project":"ProjectB","gitHubRunner":"\"ubuntu-latest\"","githubRunnerShell":"pwsh","buildMode":"Default","projectName":"ProjectB"}],"projectsCount":2}]

--- a/Actions/CreateContainers/CreateContainers.ps1
+++ b/Actions/CreateContainers/CreateContainers.ps1
@@ -6,11 +6,8 @@ param(
 )
 
 Import-Module (Join-Path -Path $PSScriptRoot -ChildPath "..\..\Scripts\Modules\Alpaca.psd1" -Resolve) -DisableNameChecking
-$ActionsDir = Resolve-Path (Join-Path -Path $PSScriptRoot -ChildPath "../../../../../")
-Write-AlpacaOutput "ActionsDir: $ActionsDir"
-gci $ActionsDir -recurse -Directory | %{Write-AlpacaOutput $_.FullName}
 $ALGoHelperPath = Join-Path -Path $PSScriptRoot -ChildPath "../../../../../microsoft/AL-Go-Actions/*/AL-Go-Helper.ps1" -Resolve
-Write-Host "ALGoHelperPath: $ALGoHelperPath"
+Write-AlpacaDebug "ALGoHelperPath: $ALGoHelperPath"
 . ($ALGoHelperPath)
 
 try {
@@ -49,3 +46,5 @@ finally {
     Add-Content -Encoding UTF8 -Path $env:GITHUB_ENV -Value "ALPACA_CONTAINERS_JSON=$($containersJson)"
     Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "containersJson=$($containersJson)"
 }
+
+throw

--- a/Actions/CreateContainers/CreateContainers.ps1
+++ b/Actions/CreateContainers/CreateContainers.ps1
@@ -29,7 +29,7 @@ try {
     foreach ($buildDimension in $BuildOrder.buildDimensions) {
         Write-AlpacaDebug "Determine whether a container is necessary for project '$($buildDimension.project)' with build mode '$($buildDimension.buildMode)'"
         $settings = ReadSettings -project $buildDimension.project -buildMode $buildDimension.buildMode
-        Write-AlpacaDebug "Settings: $($settings | convertto-json -compress)"
+        Write-AlpacaDebug "Settings: $($settings | ConvertTo-Json -depth 99 -compress)"
         if($settings.useCompilerFolder -and $settings.doNotPublishApps) {
             Write-AlpacaOutput "No container required for project '$($buildDimension.project)' with build mode '$($buildDimension.buildMode)'"
             continue

--- a/Actions/CreateContainers/CreateContainers.ps1
+++ b/Actions/CreateContainers/CreateContainers.ps1
@@ -6,7 +6,7 @@ param(
 )
 
 Import-Module (Join-Path -Path $PSScriptRoot -ChildPath "..\..\Scripts\Modules\Alpaca.psd1" -Resolve) -DisableNameChecking
-$ActionsDir = Resolve-Path (Join-Path -Path $PSScriptRoot -ChildPath "../../../../../)
+$ActionsDir = Resolve-Path (Join-Path -Path $PSScriptRoot -ChildPath "../../../../../")
 Write-AlpacaOutput "ActionsDir: $ActionsDir"
 gci $ActionsDir -recurse -Directory | %{Write-AlpacaOutput $_.FullName}
 . (Join-Path -Path $PSScriptRoot -ChildPath "../../../../../microsoft/AL-Go-Actions/AL-Go-Helper.ps1" -Resolve)

--- a/Scripts/Overrides/RunAlPipeline/PipelineInitialize.ps1
+++ b/Scripts/Overrides/RunAlPipeline/PipelineInitialize.ps1
@@ -30,7 +30,7 @@ if (! $container) {
         Id = "NOCONTAINER"
         User = "NOCONTAINER"
         Password = "NOCONTAINER"
-        Url = "NOCONTAINER"
+        Url = "https://NOCONTAINER"
     }
 }
 

--- a/Scripts/Overrides/RunAlPipeline/PipelineInitialize.ps1
+++ b/Scripts/Overrides/RunAlPipeline/PipelineInitialize.ps1
@@ -25,7 +25,13 @@ Write-AlpacaOutput "Get Alpaca container information from outputs of create cont
 $containers = @("$($Jobs.createContainers.outputs.containersJson)" | ConvertFrom-Json)
 $container = $containers | Where-Object { $_.Project -eq $project -and $_.BuildMode -eq $BuildMode }
 if (! $container) {
-    throw "No Alpaca container information for project '$project' and build mode '$BuildMode' found"
+    Write-AlpacaOutput "No Alpaca container information for project '$project' and build mode '$BuildMode' found"
+    $container = @{
+        Id = "NOCONTAINER"
+        User = "NOCONTAINER"
+        Password = "NOCONTAINER"
+        Url = "NOCONTAINER"
+    }
 }
 
 Write-AlpacaOutput "Get container authentication context from Alpaca container information"


### PR DESCRIPTION
This pull request introduces improvements to the container creation process and error handling in the pipeline scripts. The main changes include optimizing when containers are created, enhancing debug output, and making the pipeline more robust when no container is required for a given project and build mode.

### Container creation logic improvements
* [`Actions/CreateContainers/CreateContainers.ps1`](diffhunk://#diff-1ec79a4dfe9401ad0ffa10834665cdf39775e83680a74b3d75fcd8d845024d7bR30-R36): Added logic to determine if a container is necessary for each project and build mode by reading settings with `ReadSettings`. If both `useCompilerFolder` and `doNotPublishApps` are set, container creation is skipped and a message is output.
* [`Actions/CreateContainers/CreateContainers.ps1`](diffhunk://#diff-1ec79a4dfe9401ad0ffa10834665cdf39775e83680a74b3d75fcd8d845024d7bL36-R46): Improved final output message to clarify the number of containers created relative to the number of build dimensions.

### Debug and output enhancements
* [`Actions/CreateContainers/CreateContainers.ps1`](diffhunk://#diff-1ec79a4dfe9401ad0ffa10834665cdf39775e83680a74b3d75fcd8d845024d7bR9-R11): Added debug output for the resolved path to `AL-Go-Helper.ps1` and for settings used in the container creation decision.

### Pipeline robustness
* [`Scripts/Overrides/RunAlPipeline/PipelineInitialize.ps1`](diffhunk://#diff-92fd1076ed15b4e07a7e927e7e08eb89eb6b67d1679fe804657b8473a3207e4bL28-R34): When no container information is found for a project and build mode, the script now outputs a message and sets a default "NOCONTAINER" object instead of throwing an error, making the pipeline more resilient.

requires [Alpaca-PTE#83](https://github.com/cosmoconsult/Alpaca-PTE/pull/83)
part of [AB#4773](https://dev.azure.com/cc-ppi/83f75d99-795d-45dc-8543-9fe1918ff7f9/_workitems/edit/4773)