### PR TITLE
feat(PipelineInitialize): add additionalcountries warning

### DIFF
--- a/Scripts/Overrides/RunAlPipeline/PipelineInitialize.ps1
+++ b/Scripts/Overrides/RunAlPipeline/PipelineInitialize.ps1
@@ -75,7 +75,12 @@ Get-AlpacaDependencyApps -packagesFolder $packagesFolder -token $env:_token
 
 Write-AlpacaGroupEnd
 
-
+# Check Settings
+if ($additionalCountries -is [String]) { $additionalCountries = @($additionalCountries.Split(',').Trim() | Where-Object { $_ }) }
+if ($additionalCountries.Length -gt 0) {
+    Write-AlpacaDebug "Additional countries specified: $($additionalCountries -join ', ')"
+    Write-AlpacaWarning "AdditionalCountries are not supported by COSMO Alpaca. Use BuildModes to validate additional countries. https://docs.cosmoconsult.com/en-en/cloud-service/alpaca/github/" #TODO update link when site is published.
+}
 
 # Load overrides
 


### PR DESCRIPTION
This pull request adds a validation step for the `additionalCountries` parameter in the `PipelineInitialize.ps1` script. Now, if additional countries are specified, the script will output a debug message listing them and a warning that this feature is not supported, with a link to relevant documentation.

Validation and warnings for additional countries:

* Added logic to parse and validate the `additionalCountries` parameter, displaying a debug message with the specified countries and a warning that this feature is not supported by COSMO Alpaca, including a documentation link.

part of [AB#4538](https://dev.azure.com/cc-ppi/83f75d99-795d-45dc-8543-9fe1918ff7f9/_workitems/edit/4538)